### PR TITLE
Add input validations and journey ended test

### DIFF
--- a/src/main/java/com/example/geektrust/service/FileProcessor.java
+++ b/src/main/java/com/example/geektrust/service/FileProcessor.java
@@ -19,8 +19,9 @@ public class FileProcessor {
             while ((line = reader.readLine()) != null) {
                 trains.add(processLineAndReturnTrain(line.trim()));
             }
+            trainService.validateTrains(trains);
             trainService.generateOutput(trains);
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
             System.err.println("Error reading input file: " + e.getMessage());
         }
     }

--- a/src/main/java/com/example/geektrust/service/PrinterService.java
+++ b/src/main/java/com/example/geektrust/service/PrinterService.java
@@ -1,0 +1,21 @@
+package com.example.geektrust.service;
+
+import com.example.geektrust.model.Train;
+
+/**
+ * Handles printing of train details to STDOUT.
+ */
+public class PrinterService {
+
+    public void printArrival(Train train) {
+        System.out.println("ARRIVAL " + train.getTrainId() + " " + train);
+    }
+
+    public void printDeparture(Train train) {
+        System.out.println("DEPARTURE " + train.getTrainId() + " " + train);
+    }
+
+    public void printJourneyEnded() {
+        System.out.println("JOURNEY_ENDED");
+    }
+}

--- a/src/main/java/com/example/geektrust/service/TrainService.java
+++ b/src/main/java/com/example/geektrust/service/TrainService.java
@@ -17,6 +17,9 @@ public class TrainService {
         if (tokens == null || tokens.isEmpty()) {
             throw new IllegalArgumentException("Input tokens cannot be null or empty");
         }
+        if (tokens.size() < 2 || !TrainConstants.ENGINE.equals(tokens.get(1))) {
+            throw new IllegalArgumentException("Invalid format: first bogie must be ENGINE");
+        }
         String trainId = tokens.get(0);
         List<String> bogies = new ArrayList<>(tokens.subList(1, tokens.size()));
 
@@ -33,6 +36,14 @@ public class TrainService {
                 .filter(t -> id.equals(t.getTrainId()))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Missing train " + id));
+    }
+
+    public void validateTrains(List<Train> trains) {
+        boolean hasA = trains.stream().anyMatch(t -> TrainConstants.TRAIN_A.equals(t.getTrainId()));
+        boolean hasB = trains.stream().anyMatch(t -> TrainConstants.TRAIN_B.equals(t.getTrainId()));
+        if (!hasA || !hasB) {
+            throw new IllegalArgumentException("Input must contain both TRAIN_A and TRAIN_B");
+        }
     }
 
     public void generateOutput(List<Train> trains) {

--- a/src/main/java/com/example/geektrust/service/TrainService.java
+++ b/src/main/java/com/example/geektrust/service/TrainService.java
@@ -12,14 +12,11 @@ import java.util.List;
 public class TrainService {
     private final RouteService routeService = new RouteService();
     private final TrainMerger trainMerger = new TrainMerger();
+    private final ValidationService validationService = new ValidationService();
+    private final PrinterService printerService = new PrinterService();
 
     public Train createTrain(List<String> tokens) {
-        if (tokens == null || tokens.isEmpty()) {
-            throw new IllegalArgumentException("Input tokens cannot be null or empty");
-        }
-        if (tokens.size() < 2 || !TrainConstants.ENGINE.equals(tokens.get(1))) {
-            throw new IllegalArgumentException("Invalid format: first bogie must be ENGINE");
-        }
+        validationService.validateTrainTokens(tokens);
         String trainId = tokens.get(0);
         List<String> bogies = new ArrayList<>(tokens.subList(1, tokens.size()));
 
@@ -39,11 +36,7 @@ public class TrainService {
     }
 
     public void validateTrains(List<Train> trains) {
-        boolean hasA = trains.stream().anyMatch(t -> TrainConstants.TRAIN_A.equals(t.getTrainId()));
-        boolean hasB = trains.stream().anyMatch(t -> TrainConstants.TRAIN_B.equals(t.getTrainId()));
-        if (!hasA || !hasB) {
-            throw new IllegalArgumentException("Input must contain both TRAIN_A and TRAIN_B");
-        }
+        validationService.ensureBothTrainsPresent(trains);
     }
 
     public void generateOutput(List<Train> trains) {
@@ -53,14 +46,14 @@ public class TrainService {
         Train arrivalA = filterArrivalTrain(trainA);
         Train arrivalB = filterArrivalTrain(trainB);
 
-        System.out.println("ARRIVAL " + arrivalA.getTrainId() + " " + arrivalA);
-        System.out.println("ARRIVAL " + arrivalB.getTrainId() + " " + arrivalB);
+        printerService.printArrival(arrivalA);
+        printerService.printArrival(arrivalB);
 
         Train departure = trainMerger.merge(arrivalA, arrivalB);
         if (departure.getBogies().size() <= 2) {
-            System.out.println("JOURNEY_ENDED");
+            printerService.printJourneyEnded();
         } else {
-            System.out.println("DEPARTURE " + departure.getTrainId() + " " + departure);
+            printerService.printDeparture(departure);
         }
     }
 }

--- a/src/main/java/com/example/geektrust/service/ValidationService.java
+++ b/src/main/java/com/example/geektrust/service/ValidationService.java
@@ -1,0 +1,29 @@
+package com.example.geektrust.service;
+
+import com.example.geektrust.model.Train;
+import com.example.geektrust.util.TrainConstants;
+
+import java.util.List;
+
+/**
+ * Performs validation on trains and input tokens.
+ */
+public class ValidationService {
+
+    public void validateTrainTokens(List<String> tokens) {
+        if (tokens == null || tokens.isEmpty()) {
+            throw new IllegalArgumentException("Input tokens cannot be null or empty");
+        }
+        if (tokens.size() < 2 || !TrainConstants.ENGINE.equals(tokens.get(1))) {
+            throw new IllegalArgumentException("Invalid format: first bogie must be ENGINE");
+        }
+    }
+
+    public void ensureBothTrainsPresent(List<Train> trains) {
+        boolean hasA = trains.stream().anyMatch(t -> TrainConstants.TRAIN_A.equals(t.getTrainId()));
+        boolean hasB = trains.stream().anyMatch(t -> TrainConstants.TRAIN_B.equals(t.getTrainId()));
+        if (!hasA || !hasB) {
+            throw new IllegalArgumentException("Input must contain both TRAIN_A and TRAIN_B");
+        }
+    }
+}

--- a/src/test/java/com/example/geektrust/service/PrinterServiceTest.java
+++ b/src/test/java/com/example/geektrust/service/PrinterServiceTest.java
@@ -1,0 +1,43 @@
+package com.example.geektrust.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.example.geektrust.model.Train;
+
+class PrinterServiceTest {
+    private final PrinterService printer = new PrinterService();
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    private PrintStream original;
+
+    @BeforeEach
+    void setUp() {
+        original = System.out;
+        System.setOut(new PrintStream(out));
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(original);
+    }
+
+    @Test
+    void printArrivalShouldOutputArrivalLine() {
+        Train train = new Train("TRAIN_A", Arrays.asList("ENGINE", "NDL"));
+        printer.printArrival(train);
+        assertEquals("ARRIVAL TRAIN_A ENGINE NDL\n", out.toString());
+    }
+
+    @Test
+    void printJourneyEndedShouldOutputEndMessage() {
+        printer.printJourneyEnded();
+        assertEquals("JOURNEY_ENDED\n", out.toString());
+    }
+}

--- a/src/test/java/com/example/geektrust/service/TrainServiceTest.java
+++ b/src/test/java/com/example/geektrust/service/TrainServiceTest.java
@@ -47,4 +47,16 @@ class TrainServiceTest {
         assertEquals("ARRIVAL TRAIN_B ENGINE PTA", lines[1].trim());
         assertEquals("DEPARTURE TRAIN_AB ENGINE ENGINE GHY PTA NDL", lines[2].trim());
     }
+
+    @Test
+    void generateOutputShouldPrintJourneyEndedWhenNoBogiesRemain() {
+        outContent.reset();
+        Train a = new Train(TrainConstants.TRAIN_A, Arrays.asList("ENGINE"));
+        Train b = new Train(TrainConstants.TRAIN_B, Arrays.asList("ENGINE"));
+        service.generateOutput(Arrays.asList(a, b));
+        String[] lines = outContent.toString().trim().split("\n");
+        assertEquals("ARRIVAL TRAIN_A ENGINE", lines[0].trim());
+        assertEquals("ARRIVAL TRAIN_B ENGINE", lines[1].trim());
+        assertEquals("JOURNEY_ENDED", lines[2].trim());
+    }
 }

--- a/src/test/java/com/example/geektrust/service/ValidationServiceTest.java
+++ b/src/test/java/com/example/geektrust/service/ValidationServiceTest.java
@@ -1,0 +1,27 @@
+package com.example.geektrust.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.example.geektrust.model.Train;
+
+class ValidationServiceTest {
+    private final ValidationService validator = new ValidationService();
+
+    @Test
+    void validateTrainTokensShouldThrowWhenFirstIsNotEngine() {
+        assertThrows(IllegalArgumentException.class,
+                () -> validator.validateTrainTokens(Arrays.asList("TRAIN_A", "NDL")));
+    }
+
+    @Test
+    void ensureBothTrainsPresentShouldThrowWhenMissingTrain() {
+        List<Train> trains = Collections.singletonList(new Train("TRAIN_A", Arrays.asList("ENGINE")));
+        assertThrows(IllegalArgumentException.class, () -> validator.ensureBothTrainsPresent(trains));
+    }
+}


### PR DESCRIPTION
## Summary
- validate that first bogie is `ENGINE`
- ensure both trains are present when processing
- test `JOURNEY_ENDED` case

## Testing
- `mvn test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.7 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6867556f62148321b805752b47a861ac